### PR TITLE
Elizabeth/try local install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is divided into three main parts: the Pylon camera interface, the N
 
 You'll need to install some Python and Node packages to run these three components.
 
-1. Create the `bloom-desktop` environment with python 3.8 and nodejs: `mamba create --name bloom-desktop python=3.8 nodejs`
+1. Create the `bloom-desktop` environment with python 3.8 and nodejs: `mamba create --name bloom-desktop python=3.8 nodejs pip`
 2. Activate the environment: `mamba activate bloom-desktop`
 3. Install pip requirements:
    `pip install -r requirements.txt`

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ This project is divided into three main parts: the Pylon camera interface, the N
 
 You'll need to install some Python and Node packages to run these three components.
 
-1. Create the `bloom-desktop` environment: `mamba create --name bloom-desktop`
+1. Create the `bloom-desktop` environment with python 3.8 and nodejs: `mamba create --name bloom-desktop python=3.8 nodejs`
 2. Activate the environment: `mamba activate bloom-desktop`
-3. Install conda requirements: `mamba install python=3.8 nodejs nidaqmx`
 3. Install pip requirements:
    `pip install -r requirements.txt`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is divided into three main parts: the Pylon camera interface, the N
 
 You'll need to install some Python and Node packages to run these three components.
 
-1. Create the `bloom-desktop` environment with python 3.8 and nodejs: `mamba create --name bloom-desktop python=3.8 nodejs pip`
+1. Create the `bloom-desktop` environment with python 3.8 and nodejs: `mamba create --name bloom-desktop python=3.8 nodejs=18 pip -c conda-forge`
 2. Activate the environment: `mamba activate bloom-desktop`
 3. Install pip requirements:
    `pip install -r requirements.txt`

--- a/app/README.md
+++ b/app/README.md
@@ -47,5 +47,5 @@ If you already have a working installation, here is how you update the software.
 Command to run fake stream independently of the GUI:
 
 ```bash
-python pylon\pylon_stream_forever_fake.py "{\"num_frames\": 72, \"exposure_time\": 10000, \"gain\": 100, \"brightness\": 0, \"contrast\": 0, \"gamma\": 1, \"seconds_per_rot\": 7}"
+python pylon\pylon_stream_forever_fake.py "{\"num_frames\": 72, \"exposure_time\": 10000, \"gain\": 100, \"brightness\": 0, \"contrast\": 0, \"gamma\": 1, \"seconds_per_rot\": 7, \"camera_ip_address\": \"10.0.0.23\"}"
 ```

--- a/app/README.md
+++ b/app/README.md
@@ -3,20 +3,22 @@
 ## Installation
 
 1. `mamba activate bloom-desktop`
-2. Create `./.env` in this directory (see `.env.example`).
-3. Edit `./.env` with an appropriate database file location.
-4. Create `$HOME/.bloom/desktop-config.yaml` (see `desktop-config.yaml.example`).
+2. Follow the instructions in (bloom)[https://gitlab.com/salk-tm/bloom/-/tree/main?ref_type=heads] to setup a local supabase instance to interact with, and add some test data.
+3. Create `./.env` in this directory (see `.env.example`).
+4. Edit `./.env` with an appropriate database file location.
+5. Create `$HOME/.bloom/desktop-config.yaml` (see `desktop-config.yaml.example`).
     - References test images located at `test\sample_scan`.
-5. Edit `$HOME/.bloom/desktop-config.yaml` with the correct database file location and other values.
-6. Run `npm install`.
+    - Use the same environment variables as in https://gitlab.com/salk-tm/bloom/-/blob/main/web/env.dev to configure bloom-desktop to work with your local supabase instance.
+6. Edit `$HOME/.bloom/desktop-config.yaml` with the correct database file location and other values.
+7. Run `npm install`.
     - Make sure you are in `app` directory. 
     - Build tools required for this step:
          - https://visualstudio.microsoft.com/ C++ for Desktop Development on Windows
          - XCode for Mac
          - `build-essential` for Linux
     - Use `npm cache clean` to cleanup
-7. Run `npm run client:generate` to generate Typescript client for the new schema (`app\prisma\schema.prisma`)
-8. Run `npm run db:deploy` to create the database and apply the migrations.
+8. Run `npm run client:generate` to generate Typescript client for the new schema (`app\prisma\schema.prisma`)
+9. Run `npm run db:deploy` to create the database and apply the migrations.
 
 ## Quickstart
 

--- a/app/README.md
+++ b/app/README.md
@@ -40,3 +40,12 @@ If you already have a working installation, here is how you update the software.
 3. Run `npm install`.
 4. Run `npm run client:generate` to generate Typescript client for the new schema.
 5. Run `npm run db:deploy` to apply migrations.
+
+
+## Troubleshooting
+
+Command to run fake stream independently of the GUI:
+
+```bash
+python pylon\pylon_stream_forever_fake.py "{\"num_frames\": 72, \"exposure_time\": 10000, \"gain\": 100, \"brightness\": 0, \"contrast\": 0, \"gamma\": 1, \"seconds_per_rot\": 7}"
+```

--- a/app/README.md
+++ b/app/README.md
@@ -2,18 +2,25 @@
 
 ## Installation
 
-1. Create `./.env` in this directory (see `.env.example`).
-2. Edit `./.env` with an appropriate database file location.
-3. Create `$HOME/.bloom/desktop-config.yaml` (see `desktop-config.yaml.example`).
-4. Edit `$HOME/.bloom/desktop-config.yaml` with the correct database file location and other values.
-5. Run `npm install`.
-    https://visualstudio.microsoft.com/ C++ build tools required 
-6. Run `npm run client:generate` to generate Typescript client for the new schema.
-7. Run `npm run db:deploy` to create the database.
+1. `mamba activate bloom-desktop`
+2. Create `./.env` in this directory (see `.env.example`).
+3. Edit `./.env` with an appropriate database file location.
+4. Create `$HOME/.bloom/desktop-config.yaml` (see `desktop-config.yaml.example`).
+    - References test images located at `test\sample_scan`.
+5. Edit `$HOME/.bloom/desktop-config.yaml` with the correct database file location and other values.
+6. Run `npm install`.
+    - Make sure you are in `app` directory. 
+    - Build tools required for this step:
+         - https://visualstudio.microsoft.com/ C++ for Desktop Development on Windows
+         - XCode for Mac
+         - `build-essential` for Linux
+    - Use `npm cache clean` to cleanup
+7. Run `npm run client:generate` to generate Typescript client for the new schema (`app\prisma\schema.prisma`)
+8. Run `npm run db:deploy` to create the database and apply the migrations.
 
 ## Quickstart
 
-Run `npm run start`.
+Run `npm run start` from `app` directory.
 
 ## Modifying the database
 

--- a/app/README.md
+++ b/app/README.md
@@ -7,6 +7,7 @@
 3. Create `$HOME/.bloom/desktop-config.yaml` (see `desktop-config.yaml.example`).
 4. Edit `$HOME/.bloom/desktop-config.yaml` with the correct database file location and other values.
 5. Run `npm install`.
+    https://visualstudio.microsoft.com/ C++ build tools required 
 6. Run `npm run client:generate` to generate Typescript client for the new schema.
 7. Run `npm run db:deploy` to create the database.
 

--- a/pylon/pylon_fake.py
+++ b/pylon/pylon_fake.py
@@ -10,7 +10,6 @@ import logging
 
 import imageio.v2 as iio
 
-logging.basicConfig(level=logging.INFO)
 
 # Test images are in "test/sample_scan" directory from the root of the repo
 sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"

--- a/pylon/pylon_fake.py
+++ b/pylon/pylon_fake.py
@@ -14,7 +14,6 @@ logging.basicConfig(level=logging.INFO)
 
 # Test images are in "test/sample_scan" directory from the root of the repo
 sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"
-logging.info(f"sample_scan: {sample_scan}")
 
 
 async def save_image_async(executor, output_path, idx, array):

--- a/pylon/pylon_fake.py
+++ b/pylon/pylon_fake.py
@@ -6,7 +6,6 @@ import os
 import sys
 import time
 import pathlib
-import logging
 
 import imageio.v2 as iio
 

--- a/pylon/pylon_fake.py
+++ b/pylon/pylon_fake.py
@@ -6,10 +6,16 @@ import os
 import sys
 import time
 import pathlib
+import logging
 
 import imageio.v2 as iio
 
-sample_scan = '/Users/djbutler/dev/bloom-desktop-pilot/test/sample_scan'
+logging.basicConfig(level=logging.DEBUG)
+
+# sample_scan = "/Users/djbutler/dev/bloom-desktop-pilot/test/sample_scan"
+# Test images are in "test/sample_scan" directory from the root of the repo
+sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"
+logging.debug(f"sample_scan: {sample_scan}")
 
 
 async def save_image_async(executor, output_path, idx, array):

--- a/pylon/pylon_fake.py
+++ b/pylon/pylon_fake.py
@@ -12,7 +12,6 @@ import imageio.v2 as iio
 
 logging.basicConfig(level=logging.DEBUG)
 
-# sample_scan = "/Users/djbutler/dev/bloom-desktop-pilot/test/sample_scan"
 # Test images are in "test/sample_scan" directory from the root of the repo
 sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"
 logging.debug(f"sample_scan: {sample_scan}")

--- a/pylon/pylon_fake.py
+++ b/pylon/pylon_fake.py
@@ -10,7 +10,7 @@ import logging
 
 import imageio.v2 as iio
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 # Test images are in "test/sample_scan" directory from the root of the repo
 sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"

--- a/pylon/pylon_fake.py
+++ b/pylon/pylon_fake.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 # Test images are in "test/sample_scan" directory from the root of the repo
 sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"
-logging.debug(f"sample_scan: {sample_scan}")
+logging.info(f"sample_scan: {sample_scan}")
 
 
 async def save_image_async(executor, output_path, idx, array):

--- a/pylon/pylon_stream_fake.py
+++ b/pylon/pylon_stream_fake.py
@@ -15,7 +15,6 @@ from PIL import Image
 
 import imageio.v2 as iio
 
-logging.basicConfig(level=logging.INFO)
 
 # Test images are in "test/sample_scan" directory from the root of the repo
 sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"

--- a/pylon/pylon_stream_fake.py
+++ b/pylon/pylon_stream_fake.py
@@ -6,6 +6,7 @@ import os
 import sys
 import time
 import pathlib
+import logging
 
 import base64
 from io import BytesIO
@@ -14,7 +15,10 @@ from PIL import Image
 
 import imageio.v2 as iio
 
-sample_scan = "/Users/djbutler/dev/bloom-desktop-pilot/test/sample_scan"
+logging.basicConfig(level=logging.INFO)
+
+# Test images are in "test/sample_scan" directory from the root of the repo
+sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"
 
 
 def stream_frames(camera_settings):

--- a/pylon/pylon_stream_fake.py
+++ b/pylon/pylon_stream_fake.py
@@ -6,7 +6,6 @@ import os
 import sys
 import time
 import pathlib
-import logging
 
 import base64
 from io import BytesIO

--- a/pylon/pylon_stream_forever_fake.py
+++ b/pylon/pylon_stream_forever_fake.py
@@ -15,7 +15,7 @@ from PIL import Image
 
 import imageio.v2 as iio
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 # Test images are in "test/sample_scan" directory from the root of the repo
 sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"

--- a/pylon/pylon_stream_forever_fake.py
+++ b/pylon/pylon_stream_forever_fake.py
@@ -32,7 +32,6 @@ def stream_frames(camera_settings):
         # time the function call
         start = time.time()
         img = iio.imread(src_frame)
-        logging.debug(f"Read {src_frame}.")
         end = time.time()
         # print(f"iio.imread took {end - start} seconds", file=sys.stderr)
         # time the function call

--- a/pylon/pylon_stream_forever_fake.py
+++ b/pylon/pylon_stream_forever_fake.py
@@ -6,6 +6,7 @@ import os
 import sys
 import time
 import pathlib
+import logging
 
 import base64
 from io import BytesIO
@@ -14,12 +15,19 @@ from PIL import Image
 
 import imageio.v2 as iio
 
-sample_scan = "/Users/djbutler/dev/bloom-desktop-pilot/test/sample_scan"
+logging.basicConfig(level=logging.DEBUG)
+
+# sample_scan = "/Users/djbutler/dev/bloom-desktop-pilot/test/sample_scan"
+# Test images are in "test/sample_scan" directory from the root of the repo
+sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"
+logging.debug(f"sample_scan: {sample_scan}")
+
 
 
 def stream_frames(camera_settings):
     n = camera_settings["num_frames"]
     src_frames = glob.glob(os.path.join(sample_scan, "*.png"))
+    logging.debug(f"Found {len(src_frames)} frames.")
     src_frames.sort(key=lambda x: int(os.path.basename(x).split(".")[0]))
     i = 0
     while True:

--- a/pylon/pylon_stream_forever_fake.py
+++ b/pylon/pylon_stream_forever_fake.py
@@ -45,17 +45,10 @@ def stream_frames(camera_settings):
 
 
 def img_to_base64(img):
-    if img is None or img.size == 0:
-        logging.error("Invalid image encountered!")
-        return ""
-
     with BytesIO() as buffer:
         with Image.fromarray(img) as pil_img:
-            logging.debug(f"{pil_img} opened.")
             pil_img.save(buffer, format="PNG", compress_level=0)
-            logging.debug(f"{pil_img} saved to buffer.")
         base64_img = base64.b64encode(buffer.getvalue()).decode("utf-8")
-        logging.debug(f"base64_img: {base64_img[:100]}")
     return base64_img
 
 

--- a/pylon/pylon_stream_forever_fake.py
+++ b/pylon/pylon_stream_forever_fake.py
@@ -37,6 +37,7 @@ def stream_frames(camera_settings):
         # time the function call
         start = time.time()
         img = iio.imread(src_frame)
+        logging.debug(f"Read {src_frame}.")
         end = time.time()
         # print(f"iio.imread took {end - start} seconds", file=sys.stderr)
         # time the function call

--- a/pylon/pylon_stream_forever_fake.py
+++ b/pylon/pylon_stream_forever_fake.py
@@ -15,11 +15,9 @@ from PIL import Image
 
 import imageio.v2 as iio
 
-logging.basicConfig(level=logging.INFO)
 
 # Test images are in "test/sample_scan" directory from the root of the repo
 sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"
-logging.info(f"sample_scan: {sample_scan}")
 
 
 

--- a/pylon/pylon_stream_forever_fake.py
+++ b/pylon/pylon_stream_forever_fake.py
@@ -19,7 +19,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 # Test images are in "test/sample_scan" directory from the root of the repo
 sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"
-logging.debug(f"sample_scan: {sample_scan}")
+logging.info(f"sample_scan: {sample_scan}")
 
 
 

--- a/pylon/pylon_stream_forever_fake.py
+++ b/pylon/pylon_stream_forever_fake.py
@@ -6,7 +6,6 @@ import os
 import sys
 import time
 import pathlib
-import logging
 
 import base64
 from io import BytesIO
@@ -24,7 +23,6 @@ sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"
 def stream_frames(camera_settings):
     n = camera_settings["num_frames"]
     src_frames = glob.glob(os.path.join(sample_scan, "*.png"))
-    logging.debug(f"Found {len(src_frames)} frames.")
     src_frames.sort(key=lambda x: int(os.path.basename(x).split(".")[0]))
     i = 0
     while True:

--- a/pylon/pylon_stream_forever_fake.py
+++ b/pylon/pylon_stream_forever_fake.py
@@ -17,7 +17,6 @@ import imageio.v2 as iio
 
 logging.basicConfig(level=logging.DEBUG)
 
-# sample_scan = "/Users/djbutler/dev/bloom-desktop-pilot/test/sample_scan"
 # Test images are in "test/sample_scan" directory from the root of the repo
 sample_scan = pathlib.Path(__file__).parent.parent / "test" / "sample_scan"
 logging.debug(f"sample_scan: {sample_scan}")

--- a/pylon/pylon_stream_forever_fake.py
+++ b/pylon/pylon_stream_forever_fake.py
@@ -50,11 +50,17 @@ def stream_frames(camera_settings):
 
 
 def img_to_base64(img):
-    buffer = BytesIO()
-    pil_img = Image.fromarray(img)
-    pil_img.save(buffer, format="PNG", compress_level=0)
-    # iio.imwrite(buffer, img, ".png")
-    base64_img = base64.b64encode(buffer.getvalue()).decode("utf-8")
+    if img is None or img.size == 0:
+        logging.error("Invalid image encountered!")
+        return ""
+
+    with BytesIO() as buffer:
+        with Image.fromarray(img) as pil_img:
+            logging.debug(f"{pil_img} opened.")
+            pil_img.save(buffer, format="PNG", compress_level=0)
+            logging.debug(f"{pil_img} saved to buffer.")
+        base64_img = base64.b64encode(buffer.getvalue()).decode("utf-8")
+        logging.debug(f"base64_img: {base64_img[:100]}")
     return base64_img
 
 


### PR DESCRIPTION
- `nidaqmx` from `-c conda` is broken https://anaconda.org/conda-forge/nidaqmx/files
- `nidaqmx` from `pip` looks up-to-date https://pypi.org/project/nidaqmx/#history
- get the following error with `nodejs` unconstrained
```
npm error code 1
npm error path C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3
npm error command failed
npm error command C:\Windows\system32\cmd.exe /d /s /c prebuild-install || node-gyp rebuild --release
npm error copy_builtin_sqlite3
npm error   sqlite3.c
npm error   win_delay_load_hook.cc
npm error   sqlite3.vcxproj -> C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\Release\\sqlite3.lib
npm error cl : command line  warning D9025: overriding '/std:c++20' with '/std:c++17' [C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\better_sqlite3.vcxproj]
npm error   better_sqlite3.cpp
npm error C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\src\util\macros.lzz(150,35): error C2665: 'v8::ObjectTemplate::SetAccessor': no overloaded function could convert all the argument types [C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\better_sqlite3.vcxproj]
npm error   (compiling source file '../src/better_sqlite3.cpp')
npm error       C:\Users\Elizabeth\AppData\Local\node-gyp\Cache\22.9.0\include\node\v8-template.h(1055,8):
npm error       could be 'void v8::ObjectTemplate::SetAccessor(v8::Local<v8::Name>,v8::AccessorNameGetterCallback,v8::AccessorNameSetterCallback,v8::Local<v8::Value>,v8::PropertyAttribute,v8::SideEffectType,v8::SideEffectType)'
npm error           C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\src\util\macros.lzz(150,35):
npm error           'void v8::ObjectTemplate::SetAccessor(v8::Local<v8::Name>,v8::AccessorNameGetterCallback,v8::AccessorNameSetterCallback,v8::Local<v8::Value>,v8::PropertyAttribute,v8::SideEffectType,v8::SideEffectType)': cannot convert argument 2 from 'v8::AccessorGetterCallback' to 'v8::AccessorNameGetterCallback'
npm error               C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\src\util\macros.lzz(152,17):
npm error               This conversion requires a reinterpret_cast, a C-style cast or parenthesized function-style castnpm error       C:\Users\Elizabeth\AppData\Local\node-gyp\Cache\22.9.0\include\node\v8-template.h(1049,8):
npm error       or       'void v8::ObjectTemplate::SetAccessor(v8::Local<v8::String>,v8::AccessorGetterCallback,v8::AccessorSetterCallback,v8::Local<v8::Value>,v8::PropertyAttribute,v8::SideEffectType,v8::SideEffectType)'
npm error           C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\src\util\macros.lzz(150,35):
npm error           'void v8::ObjectTemplate::SetAccessor(v8::Local<v8::String>,v8::AccessorGetterCallback,v8::AccessorSetterCallback,v8::Local<v8::Value>,v8::PropertyAttribute,v8::SideEffectType,v8::SideEffectType)': cannot convert argument 5 from 'v8::AccessControl' to 'v8::PropertyAttribute'
npm error               C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\src\util\macros.lzz(155,36):
npm error               Conversion to enumeration type requires an explicit cast (static_cast, C-style cast or parenthesized function-style cast)
npm error       C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\src\util\macros.lzz(150,35):
npm error       while trying to match the argument list '(v8::Local<v8::String>, v8::AccessorGetterCallback, int, v8::Local<v8::External>, v8::AccessControl, v8::PropertyAttribute)'
npm error
npm error   test_extension.c
npm error   win_delay_load_hook.cc
npm error      Creating library C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\Release\test_extension.lib and object C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\Release\test_extension.exp
npm error   Generating code
npm error   Previous IPDB not found, fall back to full compilation.
npm error   All 3 functions were compiled because no usable IPDB/IOBJ from previous compilation was found.
npm error   Finished generating code
npm error   test_extension.vcxproj -> C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3\build\Release\\test_extension.node
npm error prebuild-install warn install No prebuilt binaries found (target=22.9.0 runtime=node arch=x64 libc= platform=win32)
npm error gyp info it worked if it ends with ok
npm error gyp info using node-gyp@9.4.1
npm error gyp info using node@22.9.0 | win32 | x64
npm error (node:16580) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
npm error (Use `node --trace-deprecation ...` to show where the warning was created)
npm error gyp info find Python using Python version 3.8.20 found at "C:\miniforge3\envs\bloom-desktop\python.exe"
npm error gyp info find VS using VS2022 (17.11.35312.102) found at:
npm error gyp info find VS "C:\Program Files\Microsoft Visual Studio\2022\Community"
npm error gyp info find VS run with --verbose for detailed information
npm error gyp info spawn C:\miniforge3\envs\bloom-desktop\python.exe
npm error gyp info spawn args [
npm error gyp info spawn args   'C:\\repos\\bloom-desktop-pilot\\app\\node_modules\\node-gyp\\gyp\\gyp_main.py',
npm error gyp info spawn args   'binding.gyp',
npm error gyp info spawn args   '-f',
npm error gyp info spawn args   'msvs',
npm error gyp info spawn args   '-I',
npm error gyp info spawn args   'C:\\repos\\bloom-desktop-pilot\\app\\node_modules\\better-sqlite3\\build\\config.gypi',npm error gyp info spawn args   '-I',
npm error gyp info spawn args   'C:\\repos\\bloom-desktop-pilot\\app\\node_modules\\node-gyp\\addon.gypi',
npm error gyp info spawn args   '-I',
npm error gyp info spawn args   'C:\\Users\\Elizabeth\\AppData\\Local\\node-gyp\\Cache\\22.9.0\\include\\node\\common.gypi',
npm error gyp info spawn args   '-Dlibrary=shared_library',
npm error gyp info spawn args   '-Dvisibility=default',
npm error gyp info spawn args   '-Dnode_root_dir=C:\\Users\\Elizabeth\\AppData\\Local\\node-gyp\\Cache\\22.9.0',
npm error gyp info spawn args   '-Dnode_gyp_dir=C:\\repos\\bloom-desktop-pilot\\app\\node_modules\\node-gyp',
npm error gyp info spawn args   '-Dnode_lib_file=C:\\\\Users\\\\Elizabeth\\\\AppData\\\\Local\\\\node-gyp\\\\Cache\\\\22.9.0\\\\<(target_arch)\\\\node.lib',
npm error gyp info spawn args   '-Dmodule_root_dir=C:\\repos\\bloom-desktop-pilot\\app\\node_modules\\better-sqlite3',
npm error gyp info spawn args   '-Dnode_engine=v8',
npm error gyp info spawn args   '--depth=.',
npm error gyp info spawn args   '--no-parallel',
npm error gyp info spawn args   '--generator-output',
npm error gyp info spawn args   'C:\\repos\\bloom-desktop-pilot\\app\\node_modules\\better-sqlite3\\build',
npm error gyp info spawn args   '-Goutput_dir=.'
npm error gyp info spawn args ]
npm error gyp info spawn C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe
npm error gyp info spawn args [
npm error gyp info spawn args   'build/binding.sln',
npm error gyp info spawn args   '/clp:Verbosity=minimal',
npm error gyp info spawn args   '/nologo',
npm error gyp info spawn args   '/p:Configuration=Release;Platform=x64'
npm error gyp info spawn args ]
npm error gyp ERR! build error
npm error gyp ERR! stack Error: `C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe` failed with exit code: 1
npm error gyp ERR! stack     at ChildProcess.onExit (C:\repos\bloom-desktop-pilot\app\node_modules\node-gyp\lib\build.js:203:23)
npm error gyp ERR! stack     at ChildProcess.emit (node:events:519:28)
npm error gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:293:12)
npm error gyp ERR! System Windows_NT 10.0.22631
npm error gyp ERR! command "C:\\miniforge3\\envs\\bloom-desktop\\node.exe" "C:\\repos\\bloom-desktop-pilot\\app\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild" "--release"
npm error gyp ERR! cwd C:\repos\bloom-desktop-pilot\app\node_modules\better-sqlite3
npm error gyp ERR! node -v v22.9.0
npm error gyp ERR! node-gyp -v v9.4.1
npm error gyp ERR! not ok
npm error A complete log of this run can be found in: C:\Users\Elizabeth\AppData\Local\npm-cache\_logs\2024-09-27T18_39_45_954Z-debug-0.log
```
- `nodejs=18.0` fixes the build issue for `better-sqlite3`
- getting the following error when trying to open the app:
```
  File "C:/repos/bloom-desktop-pilot/pylon/pylon_stream_forever_fake.py", line 60, in <module>
    stream_frames(camera_settings)
  File "C:/repos/bloom-desktop-pilot/pylon/pylon_stream_forever_fake.py", line 27, in stream_frames
    src_frame = src_frames[i % len(src_frames)]
ZeroDivisionError: integer division or modulo by zero
```
- Fixed by generalizing sample scan path https://github.com/eberrigan/bloom-desktop-pilot/blob/58fe37ece56bea45cbdf15a8861c3270149e61c1/pylon/pylon_stream_forever_fake.py#L17
- Error closing captured image? `onCaptureImage()`
```
Received line of length: 14
Received line of length: 2951656
data matches IMAGE
Received image: data:image/png;base6...
onCaptureImage() called with base64img.length:  2951650
stderr: DEBUG:PIL.PngImagePlugin:STREAM b'IHDR' 16 13
DEBUG:PIL.PngImagePlugin:STREAM b'bKGD' 41 2
DEBUG:PIL.PngImagePlugin:b'bKGD' 41 2 (unknown)
DEBUG:PIL.PngImagePlugin:STREAM b'zTXt' 55 58

stderr: DEBUG:PIL.PngImagePlugin:STREAM b'tEXt' 125 15
DEBUG:PIL.PngImagePlugin:STREAM b'IDAT' 152 8192
DEBUG:PIL.PngImagePlugin:STREAM b'IHDR' 16 13
DEBUG:PIL.PngImagePlugin:STREAM b'bKGD' 41 2
DEBUG:PIL.PngImagePlugin:b'bKGD' 41 2 (unknown)
DEBUG:PIL.PngImagePlugin:STREAM b'zTXt' 55 58
DEBUG:PIL.PngImagePlugin:STREAM b'tEXt' 125 15
DEBUG:PIL.PngImagePlugin:STREAM b'IDAT' 152 8192

stderr: DEBUG:PIL.Image:Error closing: Operation on closed image
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Updated setup instructions for the `bloom-desktop` environment to specify Python 3.8 and Node.js requirements.
	- Simplified installation steps by removing conda requirements.
	- Added a note about the necessity of C++ build tools from Visual Studio for setup.
	- Clarified steps for activating the conda environment and generating the `.env` file.
	- Specified required build tools for different operating systems and suggested using `npm cache clean` for cleanup.
	- Enhanced instructions for setting up a local Supabase instance and managing configuration files.
	- Added a troubleshooting section with commands for running a fake stream independently of the GUI.
	- Improved clarity on the database deployment instructions, including applying migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->