### PR TITLE
feat: trust Caddy's root CA for bloom-dev TLS

### DIFF
--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -16,6 +16,9 @@ const config: ForgeConfig = {
       unpack: ["**/node_modules/sharp/**/*", "**/node_modules/@img/**/*"],
     },
     icon: "./src/assets/icon",
+    // Bundles Caddy's root CA so Node can validate bloom-dev's self-signed TLS
+    // until Let's Encrypt is wired up. Loaded via NODE_EXTRA_CA_CERTS in main.ts.
+    extraResource: ["./src/assets/bloom-caddy-root.crt"],
   },
   rebuildConfig: {},
   makers: [

--- a/app/src/assets/bloom-caddy-root.crt
+++ b/app/src/assets/bloom-caddy-root.crt
@@ -1,0 +1,15 @@
+PLACEHOLDER — REPLACE BEFORE BUILDING THE APP
+
+This file must contain Caddy's root CA certificate (PEM format,
+starting with `-----BEGIN CERTIFICATE-----`).
+
+To populate it, run on a machine with SSH access to bloom-dev:
+
+    ssh <user>@bloom-dev.salk.edu \
+      "docker exec bloom_v2_prod-caddy-1 cat /data/caddy/pki/authorities/local/root.crt" \
+      > app/src/assets/bloom-caddy-root.crt
+
+The cert is used by NODE_EXTRA_CA_CERTS in main.ts to trust Caddy's
+self-signed TLS endpoint at bloom-dev.salk.edu. Once Let's Encrypt
+is wired up on bloom-dev, this file (and the NODE_EXTRA_CA_CERTS
+line in main.ts) can be removed.

--- a/app/src/assets/bloom-caddy-root.crt
+++ b/app/src/assets/bloom-caddy-root.crt
@@ -3,12 +3,6 @@ PLACEHOLDER — REPLACE BEFORE BUILDING THE APP
 This file must contain Caddy's root CA certificate (PEM format,
 starting with `-----BEGIN CERTIFICATE-----`).
 
-To populate it, run on a machine with SSH access to bloom-dev:
-
-    ssh <user>@bloom-dev.salk.edu \
-      "docker exec bloom_v2_prod-caddy-1 cat /data/caddy/pki/authorities/local/root.crt" \
-      > app/src/assets/bloom-caddy-root.crt
-
 The cert is used by NODE_EXTRA_CA_CERTS in main.ts to trust Caddy's
 self-signed TLS endpoint at bloom-dev.salk.edu. Once Let's Encrypt
 is wired up on bloom-dev, this file (and the NODE_EXTRA_CA_CERTS

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -1,6 +1,14 @@
 import { app, BrowserWindow, dialog, ipcMain } from "electron";
 
 import path from "path";
+
+// Trust Caddy's self-signed root CA when talking to bloom-dev's TLS endpoints
+// (until Let's Encrypt is wired up). Must run before any HTTPS call.
+const caddyRootCertPath = app.isPackaged
+  ? path.join(process.resourcesPath, "bloom-caddy-root.crt")
+  : path.join(__dirname, "..", "..", "src", "assets", "bloom-caddy-root.crt");
+process.env.NODE_EXTRA_CA_CERTS = caddyRootCertPath;
+
 import { resolveHtmlPath } from "./util";
 // import { createBloomRetriever, getSupabaseJWT } from "./bloom";
 import * as os from "node:os";


### PR DESCRIPTION
## Summary
- Trust Caddy's root CA so Bloom Desktop can write to bloom-dev's HTTPS endpoints
- Required because bloom-dev currently uses `tls internal` (self-signed)
- Temporary workaround until SSL certs from a trusted CA are wired up

## Test plan
- [ ] Replace the placeholder `app/src/assets/bloom-caddy-root.crt` with the actual cert (instructions in the file)
- [ ] `npm run make` produces installer
- [ ] Install and launch — Bloom Desktop connects to bloom-dev without TLS errors
- [ ] Image upload to V2 prod succeeds