### PR TITLE
feat: inject ws package as Supabase Realtime transport

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bloom-desktop-pilot",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bloom-desktop-pilot",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^5.16.1",
@@ -30,6 +30,7 @@
         "react-drag-drop-files": "^3.0.1",
         "react-router-dom": "^6.22.0",
         "sharp": "^0.33.2",
+        "ws": "^8.20.1",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -42,6 +43,7 @@
         "@electron-forge/plugin-webpack": "^7.2.0",
         "@types/react": "^18.2.55",
         "@types/react-dom": "^18.2.19",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "@vercel/webpack-asset-relocator-loader": "1.7.3",
@@ -14387,10 +14389,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "@electron-forge/plugin-webpack": "^7.2.0",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "@vercel/webpack-asset-relocator-loader": "1.7.3",
@@ -74,6 +75,7 @@
     "react-drag-drop-files": "^3.0.1",
     "react-router-dom": "^6.22.0",
     "sharp": "^0.33.2",
+    "ws": "^8.20.1",
     "zod": "^3.22.4"
   }
 }

--- a/app/src/main/bloom.ts
+++ b/app/src/main/bloom.ts
@@ -3,6 +3,7 @@ import path from "path";
 import * as os from "os";
 import * as yaml from "js-yaml";
 import { createClient } from "@supabase/supabase-js";
+import ws from "ws";
 // import { LocalStorage } from './local-storage';
 import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -71,7 +72,10 @@ async function getSupabaseClient() {
 
   const supabase = createClient<Database>(
     config.bloom_api_url,
-    config.bloom_anon_key
+    config.bloom_anon_key,
+    {
+      realtime: { transport: ws as any },
+    }
   );
   await supabase.auth.signInWithPassword(clientCredentials);
 

--- a/app/src/main/imageuploader.ts
+++ b/app/src/main/imageuploader.ts
@@ -3,6 +3,7 @@ import path from "path";
 import * as os from "os";
 import * as yaml from "js-yaml";
 import { createClient } from "@supabase/supabase-js";
+import ws from "ws";
 import pLimit from "p-limit";
 
 import sharp from "sharp";
@@ -380,7 +381,10 @@ async function getSupabaseClient() {
 
   const supabase = createClient<Database>(
     config.bloom_api_url,
-    config.bloom_anon_key
+    config.bloom_anon_key,
+    {
+      realtime: { transport: ws as any },
+    }
   );
   await supabase.auth.signInWithPassword(clientCredentials);
 


### PR DESCRIPTION
## Summary
- Electron main process is Node.js — no native WebSocket global
- `@supabase/supabase-js`'s Realtime client fails to set up channels without one
- Inject [`ws`](https://www.npmjs.com/package/ws) as the transport so Realtime works in the main process

## Changes
- `app/src/main/bloom.ts` — pass `realtime: { transport: ws }` to `createClient`
- `app/src/main/imageuploader.ts` — same
- `app/package.json` — add `ws` + `@types/ws`
- `app/package-lock.json` — regenerated with `npm install --package-lock-only` (focused 13-line diff)

## Test plan
- [ ] `npm run start` — Bloom Desktop launches without WebSocket errors in main process logs
- [ ] Image upload to V2 prod succeeds end-to-end
- [ ] Realtime subscriptions (if used elsewhere) connect successfully

## Companion PR
[#55](https://github.com/eberrigan/bloom-desktop-pilot/pull/55) handles TLS trust for bloom-dev's self-signed cert. Both are needed for Bloom Desktop ↔ V2 prod to fully work.